### PR TITLE
adding link to nft contract in nftgallery.jsx

### DIFF
--- a/frontend/components/nftGallery.jsx
+++ b/frontend/components/nftGallery.jsx
@@ -211,19 +211,23 @@ function NftCard({ nft }) {
 							/>
 						) : null}
 					</div>
-					<div className={styles.contract_container}>
-						<p className={styles.contract_container}>
-							{nft.contract.slice(0, 6)}...
-							{nft.contract.slice(38)}
-						</p>
-						<img
-							src={
-								"https://etherscan.io/images/brandassets/etherscan-logo-circle.svg"
-							}
-							width="15px"
-							height="15px"
-						/>
-					</div>
+					<a
+            href={`https://etherscan.io/address/${nft.contract}`}
+            className={styles.contract_container}
+            target="_blank"
+          >
+            <p>
+              {nft.contract.slice(0, 6)}...
+              {nft.contract.slice(38)}
+            </p>
+            <img
+              src={
+                "https://etherscan.io/images/brandassets/etherscan-logo-circle.svg"
+              }
+              width="15px"
+              height="15px"
+            />
+          </a>
 				</div>
 
 				<div className={styles.description_container}>


### PR DESCRIPTION
To solve Issue #1  - replaced the `div` with class of `contract_container`,  with an `<a>`.

<img width="404" alt="Screenshot 2023-03-02 at 5 47 45 PM" src="https://user-images.githubusercontent.com/71395931/222610766-9c51bca9-f867-4427-b974-78eb672df102.png">
<img width="385" alt="Screenshot 2023-03-02 at 5 48 02 PM" src="https://user-images.githubusercontent.com/71395931/222610810-7bf2c9c5-5fd6-4c2e-8934-a630fe8d9d06.png">
