### PR TITLE
Responsive inputs

### DIFF
--- a/frontend/components/nftGallery.jsx
+++ b/frontend/components/nftGallery.jsx
@@ -96,25 +96,27 @@ export default function NFTGallery({}) {
 								setWalletOrCollectionAddress(e.target.value);
 							}}
 							placeholder="Insert NFTs contract or wallet address"
-						></input>
-						<div className={styles.select_container_alt}>
-							<select
-								onChange={(e) => {
-									setChain(e.target.value);
-								}}
-								defaultValue={process.env.ALCHEMY_NETWORK}
+						/>
+						<div className={styles.buttons_under_input}>
+							<div className={styles.select_container_alt}>
+								<select
+									onChange={(e) => {
+										setChain(e.target.value);
+									}}
+									defaultValue={process.env.ALCHEMY_NETWORK}
+								>
+									<option value={"ETH_MAINNET"}>Mainnet</option>
+									<option value={"MATIC_MAINNET"}>Polygon</option>
+									<option value={"ETH_GOERLI"}>Goerli</option>
+									<option value={"MATIC_MUMBAI"}>Mumbai</option>
+								</select>
+							</div>
+							<div
+								onClick={() => fetchNFTs()}
+								className={styles.button_black}
 							>
-								<option value={"ETH_MAINNET"}>Mainnet</option>
-								<option value={"MATIC_MAINNET"}>Polygon</option>
-								<option value={"ETH_GOERLI"}>Goerli</option>
-								<option value={"MATIC_MUMBAI"}>Mumbai</option>
-							</select>
-						</div>
-						<div
-							onClick={() => fetchNFTs()}
-							className={styles.button_black}
-						>
-							<a>Search</a>
+								<a>Search</a>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/frontend/styles/NftGallery.module.css
+++ b/frontend/styles/NftGallery.module.css
@@ -80,9 +80,6 @@
   .input_button_container input{
     width: 70%;
   }
-  .buttons_under_input{
-    display: flex;
-  }
 }
 
 .select_container_alt{

--- a/frontend/styles/NftGallery.module.css
+++ b/frontend/styles/NftGallery.module.css
@@ -64,14 +64,31 @@
     outline: none;
     border: 1px solid #CFD9F0;
     border-radius: 8px;
-width: 528px;
-;
- 
+    width: 528px;
+}
+
+.buttons_under_input{
+  display: flex;
+}
+
+@media screen and (max-width: 750px) {
+  .input_button_container{
+    flex-direction: column;
+    align-items: center;
+    justify-self: center;
+  }
+  .input_button_container input{
+    width: 70%;
+  }
+  .buttons_under_input{
+    display: flex;
+  }
 }
 
 .select_container_alt{
     text-align: center;
     padding: .6rem 1rem;
+    margin-right: 1rem;
     display: flex;
     border-radius: 3px;
     background-color: black;


### PR DESCRIPTION
__**SOLVES ISSUE**__ #5

**nftGallery.jsx:**
Adding a `<div>`that houses the 2 buttons after the text input. Also just making the `<input>` self-closing.

**NftGallery.module.css:**
Styling that `<div>` to display flex.

Making media query for `.input_button_container` and it's `<input>` to switch to column direction and take up less space on smaller screens.

<img width="1379" alt="Screenshot 2023-03-20 at 9 27 03 AM" src="https://user-images.githubusercontent.com/71395931/226405483-7832e015-2eed-4a28-b088-4c2b92c16c5d.png">
<img width="457" alt="Screenshot 2023-03-20 at 9 27 13 AM" src="https://user-images.githubusercontent.com/71395931/226405492-5313f6e5-71e7-435a-afca-4a49c64d0016.png">
